### PR TITLE
Apply clang-tidy autofixes

### DIFF
--- a/velox/experimental/cudf/connectors/parquet/ParquetDataSink.cpp
+++ b/velox/experimental/cudf/connectors/parquet/ParquetDataSink.cpp
@@ -76,26 +76,26 @@ std::string makeUuid() {
 
 cudf::io::compression_type getCompressionType(
     facebook::velox::common::CompressionKind name) {
-  using compression_type = cudf::io::compression_type;
+  using CompressionType = cudf::io::compression_type;
 
   static std::unordered_map<
       facebook::velox::common::CompressionKind,
-      compression_type> const map = {
+      CompressionType> const kMap = {
       {facebook::velox::common::CompressionKind::CompressionKind_NONE,
-       compression_type::NONE},
+       CompressionType::NONE},
       {facebook::velox::common::CompressionKind::CompressionKind_SNAPPY,
-       compression_type::SNAPPY},
+       CompressionType::SNAPPY},
       {facebook::velox::common::CompressionKind::CompressionKind_LZ4,
-       compression_type::LZ4},
+       CompressionType::LZ4},
       {facebook::velox::common::CompressionKind::CompressionKind_ZSTD,
-       compression_type::ZSTD}};
+       CompressionType::ZSTD}};
 
   VELOX_CHECK(
-      map.find(name) != map.end(),
+      kMap.find(name) != kMap.end(),
       "Unsupported compression type requested. Supported compression types are: "
       "NONE, SNAPPY, LZ4, ZSTD");
 
-  return map.at(name);
+  return kMap.at(name);
 }
 
 std::shared_ptr<memory::MemoryPool> createSinkPool(
@@ -112,14 +112,14 @@ std::shared_ptr<memory::MemoryPool> createSortPool(
 
 const std::string LocationHandle::tableTypeName(
     LocationHandle::TableType type) {
-  static const auto tableTypes = tableTypeNames();
-  return tableTypes.at(type);
+  static const auto kTableTypes = tableTypeNames();
+  return kTableTypes.at(type);
 }
 
 LocationHandle::TableType LocationHandle::tableTypeFromName(
     const std::string& name) {
-  static const auto nameTableTypes = invertMap(tableTypeNames());
-  return nameTableTypes.at(name);
+  static const auto kNameTableTypes = invertMap(tableTypeNames());
+  return kNameTableTypes.at(name);
 }
 
 ParquetDataSink::ParquetDataSink(
@@ -220,9 +220,7 @@ ParquetDataSink::createCudfWriter(cudf::table_view cudfTable) {
     std::for_each(
         tableInputMetadata.column_metadata.begin(),
         tableInputMetadata.column_metadata.end(),
-        [=](auto& col_meta) {
-          col_meta.set_encoding(writerOptions->encoding);
-        });
+        [=](auto& colMeta) { colMeta.set_encoding(writerOptions->encoding); });
 
     cudfWriterOptions.set_row_group_size_bytes(
         writerOptions->rowGroupSizeBytes);

--- a/velox/experimental/cudf/connectors/parquet/ParquetDataSource.h
+++ b/velox/experimental/cudf/connectors/parquet/ParquetDataSource.h
@@ -92,7 +92,7 @@ class ParquetDataSource : public DataSource, public NvtxHelper {
   std::shared_ptr<ParquetConnectorSplit> split_;
   std::shared_ptr<ParquetTableHandle> tableHandle_;
 
-  const std::shared_ptr<ParquetConfig> ParquetConfig_;
+  const std::shared_ptr<ParquetConfig> parquetConfig_;
 
   folly::Executor* const executor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
@@ -105,7 +105,7 @@ class ParquetDataSource : public DataSource, public NvtxHelper {
   rmm::cuda_stream_view stream_;
 
   // Table column names read from the Parquet file
-  std::vector<std::string> columnNames;
+  std::vector<std::string> columnNames_;
 
   // Output type from file reader.  This is different from outputType_ that it
   // contains column names before assignment, and columns that only used in

--- a/velox/experimental/cudf/exec/CudfFilterProject.h
+++ b/velox/experimental/cudf/exec/CudfFilterProject.h
@@ -47,11 +47,11 @@ class CudfFilterProject : public exec::Operator, public NvtxHelper {
   RowVectorPtr getOutput() override;
 
   void filter(
-      std::vector<std::unique_ptr<cudf::column>>& input_table_columns,
+      std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
       rmm::cuda_stream_view stream);
 
   std::vector<std::unique_ptr<cudf::column>> project(
-      std::vector<std::unique_ptr<cudf::column>>& input_table_columns,
+      std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
       rmm::cuda_stream_view stream);
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -68,15 +68,15 @@ using namespace facebook::velox;
                                                                               \
     std::unique_ptr<cudf::column> doReduce(                                   \
         cudf::table_view const& input,                                        \
-        TypePtr const& output_type,                                           \
+        TypePtr const& outputType,                                            \
         rmm::cuda_stream_view stream) override {                              \
-      auto const agg_request =                                                \
+      auto const aggRequest =                                                 \
           cudf::make_##name##_aggregation<cudf::reduce_aggregation>();        \
-      auto const cudf_output_type =                                           \
-          cudf::data_type(cudf_velox::velox_to_cudf_type_id(output_type));    \
-      auto const result_scalar = cudf::reduce(                                \
-          input.column(inputIndex), *agg_request, cudf_output_type, stream);  \
-      return cudf::make_column_from_scalar(*result_scalar, 1, stream);        \
+      auto const cudfOutputType =                                             \
+          cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));         \
+      auto const resultScalar = cudf::reduce(                                 \
+          input.column(inputIndex), *aggRequest, cudfOutputType, stream);     \
+      return cudf::make_column_from_scalar(*resultScalar, 1, stream);         \
     }                                                                         \
                                                                               \
    private:                                                                   \
@@ -92,53 +92,53 @@ struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       core::AggregationNode::Step step,
       uint32_t inputIndex,
       VectorPtr constant,
-      bool is_global)
+      bool isGlobal)
       : Aggregator(
             step,
             cudf::aggregation::COUNT_VALID,
             inputIndex,
             constant,
-            is_global) {}
+            isGlobal) {}
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
       std::vector<cudf::groupby::aggregation_request>& requests) override {
     auto& request = requests.emplace_back();
-    output_idx = requests.size() - 1;
+    outputIdx_ = requests.size() - 1;
     request.values = tbl.column(constant == nullptr ? inputIndex : 0);
-    std::unique_ptr<cudf::groupby_aggregation> agg_request =
+    std::unique_ptr<cudf::groupby_aggregation> aggRequest =
         exec::isRawInput(step)
         ? cudf::make_count_aggregation<cudf::groupby_aggregation>(
               constant == nullptr ? cudf::null_policy::EXCLUDE
                                   : cudf::null_policy::INCLUDE)
         : cudf::make_sum_aggregation<cudf::groupby_aggregation>();
-    request.aggregations.push_back(std::move(agg_request));
+    request.aggregations.push_back(std::move(aggRequest));
   }
 
   std::unique_ptr<cudf::column> doReduce(
       cudf::table_view const& input,
-      TypePtr const& output_type,
+      TypePtr const& outputType,
       rmm::cuda_stream_view stream) override {
     if (exec::isRawInput(step)) {
       // For raw input, implement count using size + null count
-      auto input_col = input.column(constant == nullptr ? inputIndex : 0);
+      auto inputCol = input.column(constant == nullptr ? inputIndex : 0);
 
       // count_valid: size - null_count, count_all: just the size
       int64_t count = constant == nullptr
-          ? input_col.size() - input_col.null_count()
-          : input_col.size();
+          ? inputCol.size() - inputCol.null_count()
+          : inputCol.size();
 
-      auto result_scalar = cudf::numeric_scalar<int64_t>(count);
+      auto resultScalar = cudf::numeric_scalar<int64_t>(count);
 
-      return cudf::make_column_from_scalar(result_scalar, 1, stream);
+      return cudf::make_column_from_scalar(resultScalar, 1, stream);
     } else {
       // For non-raw input (intermediate/final), use sum aggregation
-      auto const agg_request =
+      auto const aggRequest =
           cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-      auto const cudf_output_type = cudf::data_type(cudf::type_id::INT64);
-      auto const result_scalar = cudf::reduce(
-          input.column(inputIndex), *agg_request, cudf_output_type, stream);
-      return cudf::make_column_from_scalar(*result_scalar, 1, stream);
+      auto const cudfOutputType = cudf::data_type(cudf::type_id::INT64);
+      auto const resultScalar = cudf::reduce(
+          input.column(inputIndex), *aggRequest, cudfOutputType, stream);
+      return cudf::make_column_from_scalar(*resultScalar, 1, stream);
     }
     return nullptr;
   }
@@ -147,7 +147,7 @@ struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       std::vector<cudf::groupby::aggregation_result>& results,
       rmm::cuda_stream_view stream) override {
     // cudf produces int32 for count(0) but velox expects int64
-    auto col = std::move(results[output_idx].results[0]);
+    auto col = std::move(results[outputIdx_].results[0]);
     if (constant != nullptr &&
         col->type() == cudf::data_type(cudf::type_id::INT32)) {
       col = cudf::cast(*col, cudf::data_type(cudf::type_id::INT64), stream);
@@ -156,7 +156,7 @@ struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
   }
 
  private:
-  uint32_t output_idx;
+  uint32_t outputIdx_;
 };
 
 struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
@@ -164,13 +164,13 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       core::AggregationNode::Step step,
       uint32_t inputIndex,
       VectorPtr constant,
-      bool is_global)
+      bool isGlobal)
       : Aggregator(
             step,
             cudf::aggregation::MEAN,
             inputIndex,
             constant,
-            is_global) {}
+            isGlobal) {}
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
@@ -178,7 +178,7 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
     switch (step) {
       case core::AggregationNode::Step::kSingle: {
         auto& request = requests.emplace_back();
-        mean_idx = requests.size() - 1;
+        meanIdx_ = requests.size() - 1;
         request.values = tbl.column(inputIndex);
         request.aggregations.push_back(
             cudf::make_mean_aggregation<cudf::groupby_aggregation>());
@@ -186,7 +186,7 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       }
       case core::AggregationNode::Step::kPartial: {
         auto& request = requests.emplace_back();
-        sum_idx = requests.size() - 1;
+        sumIdx_ = requests.size() - 1;
         request.values = tbl.column(inputIndex);
         request.aggregations.push_back(
             cudf::make_sum_aggregation<cudf::groupby_aggregation>());
@@ -199,13 +199,13 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
         // In final aggregation, the previously computed sum and count are in
         // the child columns of the input column.
         auto& request = requests.emplace_back();
-        sum_idx = requests.size() - 1;
+        sumIdx_ = requests.size() - 1;
         request.values = tbl.column(inputIndex).child(0);
         request.aggregations.push_back(
             cudf::make_sum_aggregation<cudf::groupby_aggregation>());
 
         auto& request2 = requests.emplace_back();
-        count_idx = requests.size() - 1;
+        countIdx_ = requests.size() - 1;
         request2.values = tbl.column(inputIndex).child(1);
         // The counts are already computed in partial aggregation, so we just
         // need to sum them up again.
@@ -224,19 +224,19 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       rmm::cuda_stream_view stream) override {
     switch (step) {
       case core::AggregationNode::Step::kSingle:
-        return std::move(results[mean_idx].results[0]);
+        return std::move(results[meanIdx_].results[0]);
       case core::AggregationNode::Step::kPartial: {
-        auto sum = std::move(results[sum_idx].results[0]);
-        auto count = std::move(results[sum_idx].results[1]);
+        auto sum = std::move(results[sumIdx_].results[0]);
+        auto count = std::move(results[sumIdx_].results[1]);
 
         auto const size = sum->size();
 
-        auto count_int64 =
+        auto countInt64 =
             cudf::cast(*count, cudf::data_type(cudf::type_id::INT64), stream);
 
         auto children = std::vector<std::unique_ptr<cudf::column>>();
         children.push_back(std::move(sum));
-        children.push_back(std::move(count_int64));
+        children.push_back(std::move(countInt64));
 
         // TODO: Handle nulls. This can happen if all values are null in a
         // group.
@@ -249,8 +249,8 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
             std::move(children));
       }
       case core::AggregationNode::Step::kFinal: {
-        auto sum = std::move(results[sum_idx].results[0]);
-        auto count = std::move(results[count_idx].results[0]);
+        auto sum = std::move(results[sumIdx_].results[0]);
+        auto count = std::move(results[countIdx_].results[0]);
         auto avg = cudf::binary_operation(
             *sum,
             *count,
@@ -268,39 +268,39 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
 
   std::unique_ptr<cudf::column> doReduce(
       cudf::table_view const& input,
-      TypePtr const& output_type,
+      TypePtr const& outputType,
       rmm::cuda_stream_view stream) override {
     switch (step) {
       case core::AggregationNode::Step::kSingle: {
-        auto const agg_request =
+        auto const aggRequest =
             cudf::make_mean_aggregation<cudf::reduce_aggregation>();
-        auto const cudf_output_type =
-            cudf::data_type(cudf_velox::velox_to_cudf_type_id(output_type));
-        auto const result_scalar = cudf::reduce(
-            input.column(inputIndex), *agg_request, cudf_output_type, stream);
-        return cudf::make_column_from_scalar(*result_scalar, 1, stream);
+        auto const cudfOutputType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));
+        auto const resultScalar = cudf::reduce(
+            input.column(inputIndex), *aggRequest, cudfOutputType, stream);
+        return cudf::make_column_from_scalar(*resultScalar, 1, stream);
       }
       case core::AggregationNode::Step::kPartial: {
-        VELOX_CHECK(output_type->isRow());
-        auto const& row_type = output_type->asRow();
-        auto const sum_type = row_type.childAt(0);
-        auto const count_type = row_type.childAt(1);
-        auto const cudf_sum_type =
-            cudf::data_type(cudf_velox::velox_to_cudf_type_id(sum_type));
-        auto const cudf_count_type =
-            cudf::data_type(cudf_velox::velox_to_cudf_type_id(count_type));
+        VELOX_CHECK(outputType->isRow());
+        auto const& rowType = outputType->asRow();
+        auto const sumType = rowType.childAt(0);
+        auto const countType = rowType.childAt(1);
+        auto const cudfSumType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(sumType));
+        auto const cudfCountType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(countType));
 
         // sum
-        auto const agg_request =
+        auto const aggRequest =
             cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-        auto const sum_result_scalar = cudf::reduce(
-            input.column(inputIndex), *agg_request, cudf_sum_type, stream);
-        auto sum_col =
-            cudf::make_column_from_scalar(*sum_result_scalar, 1, stream);
+        auto const sumResultScalar = cudf::reduce(
+            input.column(inputIndex), *aggRequest, cudfSumType, stream);
+        auto sumCol =
+            cudf::make_column_from_scalar(*sumResultScalar, 1, stream);
 
         // libcudf doesn't have a count agg for reduce. What we want is to
         // count the number of valid rows.
-        auto count_col = cudf::make_column_from_scalar(
+        auto countCol = cudf::make_column_from_scalar(
             cudf::numeric_scalar<int64_t>(
                 input.column(inputIndex).size() -
                 input.column(inputIndex).null_count()),
@@ -309,8 +309,8 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
 
         // Assemble into struct as expected by velox.
         auto children = std::vector<std::unique_ptr<cudf::column>>();
-        children.push_back(std::move(sum_col));
-        children.push_back(std::move(count_col));
+        children.push_back(std::move(sumCol));
+        children.push_back(std::move(countCol));
         return std::make_unique<cudf::column>(
             cudf::data_type(cudf::type_id::STRUCT),
             1,
@@ -321,31 +321,31 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       }
       case core::AggregationNode::Step::kFinal: {
         // Input column has two children: sum and count
-        auto const sum_col = input.column(inputIndex).child(0);
-        auto const count_col = input.column(inputIndex).child(1);
+        auto const sumCol = input.column(inputIndex).child(0);
+        auto const countCol = input.column(inputIndex).child(1);
 
         // sum the sums
-        auto const sum_agg_request =
+        auto const sumAggRequest =
             cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-        auto const sum_result_scalar =
-            cudf::reduce(sum_col, *sum_agg_request, sum_col.type(), stream);
-        auto sum_result_col =
-            cudf::make_column_from_scalar(*sum_result_scalar, 1, stream);
+        auto const sumResultScalar =
+            cudf::reduce(sumCol, *sumAggRequest, sumCol.type(), stream);
+        auto sumResultCol =
+            cudf::make_column_from_scalar(*sumResultScalar, 1, stream);
 
         // sum the counts
-        auto const count_agg_request =
+        auto const countAggRequest =
             cudf::make_sum_aggregation<cudf::reduce_aggregation>();
-        auto const count_result_scalar = cudf::reduce(
-            count_col, *count_agg_request, count_col.type(), stream);
+        auto const countResultScalar =
+            cudf::reduce(countCol, *countAggRequest, countCol.type(), stream);
 
         // divide the sums by the counts
-        auto const cudf_output_type =
-            cudf::data_type(cudf_velox::velox_to_cudf_type_id(output_type));
+        auto const cudfOutputType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));
         return cudf::binary_operation(
-            *sum_result_col,
-            *count_result_scalar,
+            *sumResultCol,
+            *countResultScalar,
             cudf::binary_operator::DIV,
-            cudf_output_type,
+            cudfOutputType,
             stream);
       }
       default:
@@ -356,9 +356,9 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
  private:
   // These indices are used to track where the desired result columns
   // (mean/<sum, count>) are in the output of cudf::groupby::aggregate().
-  uint32_t mean_idx;
-  uint32_t sum_idx;
-  uint32_t count_idx;
+  uint32_t meanIdx_;
+  uint32_t sumIdx_;
+  uint32_t countIdx_;
 };
 
 std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
@@ -366,22 +366,22 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
     std::string const& kind,
     uint32_t inputIndex,
     VectorPtr constant,
-    bool is_global) {
+    bool isGlobal) {
   if (kind == "sum") {
     return std::make_unique<SumAggregator>(
-        step, inputIndex, constant, is_global);
+        step, inputIndex, constant, isGlobal);
   } else if (kind == "count") {
     return std::make_unique<CountAggregator>(
-        step, inputIndex, constant, is_global);
+        step, inputIndex, constant, isGlobal);
   } else if (kind == "min") {
     return std::make_unique<MinAggregator>(
-        step, inputIndex, constant, is_global);
+        step, inputIndex, constant, isGlobal);
   } else if (kind == "max") {
     return std::make_unique<MaxAggregator>(
-        step, inputIndex, constant, is_global);
+        step, inputIndex, constant, isGlobal);
   } else if (kind == "avg") {
     return std::make_unique<MeanAggregator>(
-        step, inputIndex, constant, is_global);
+        step, inputIndex, constant, isGlobal);
   } else {
     VELOX_NYI("Aggregation not yet supported");
   }
@@ -397,17 +397,17 @@ auto toAggregators(
   std::vector<std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator>>
       aggregators;
   for (auto const& aggregate : aggregationNode.aggregates()) {
-    std::vector<column_index_t> agg_inputs;
-    std::vector<VectorPtr> agg_constants;
+    std::vector<column_index_t> aggInputs;
+    std::vector<VectorPtr> aggConstants;
     for (auto const& arg : aggregate.call->inputs()) {
       if (auto const field =
               dynamic_cast<core::FieldAccessTypedExpr const*>(arg.get())) {
-        agg_inputs.push_back(inputRowSchema->getChildIdx(field->name()));
+        aggInputs.push_back(inputRowSchema->getChildIdx(field->name()));
       } else if (
           auto constant =
               dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
-        agg_inputs.push_back(kConstantChannel);
-        agg_constants.push_back(constant->toConstantVector(operatorCtx.pool()));
+        aggInputs.push_back(kConstantChannel);
+        aggConstants.push_back(constant->toConstantVector(operatorCtx.pool()));
       } else {
         VELOX_NYI("Constants and lambdas not yet supported");
       }
@@ -417,15 +417,15 @@ auto toAggregators(
     // be multiple inputs to an aggregate.
     // We're postponing properly supporting this for now because the currently
     // supported aggregation functions in cudf_velox don't use it.
-    VELOX_CHECK(agg_inputs.size() == 1);
+    VELOX_CHECK(aggInputs.size() == 1);
 
     if (aggregate.distinct) {
       VELOX_NYI("De-dup before aggregation is not yet supported");
     }
 
     auto const kind = aggregate.call->name();
-    auto const inputIndex = agg_inputs[0];
-    auto const constant = agg_constants.empty() ? nullptr : agg_constants[0];
+    auto const inputIndex = aggInputs[0];
+    auto const constant = aggConstants.empty() ? nullptr : aggConstants[0];
     aggregators.push_back(
         createAggregator(step, kind, inputIndex, constant, isGlobal));
   }
@@ -523,24 +523,24 @@ void CudfHashAggregation::setupGroupingKeyChannelProjections(
 void CudfHashAggregation::addInput(RowVectorPtr input) {
   // Accumulate inputs
   if (input->size() > 0) {
-    auto cudf_input = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
-    VELOX_CHECK_NOT_NULL(cudf_input);
-    inputs_.push_back(std::move(cudf_input));
+    auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    inputs_.push_back(std::move(cudfInput));
   }
 }
 
 RowVectorPtr CudfHashAggregation::doGroupByAggregation(
     std::unique_ptr<cudf::table> tbl,
     rmm::cuda_stream_view stream) {
-  auto groupby_key_view = tbl->select(
+  auto groupbyKeyView = tbl->select(
       groupingKeyInputChannels_.begin(), groupingKeyInputChannels_.end());
 
-  size_t const num_grouping_keys = groupby_key_view.num_columns();
+  size_t const numGroupingKeys = groupbyKeyView.num_columns();
 
   // TODO: All other args to groupby are related to sort groupby. We don't
   // support optimizations related to it yet.
-  cudf::groupby::groupby group_by_owner(
-      groupby_key_view,
+  cudf::groupby::groupby groupByOwner(
+      groupbyKeyView,
       ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
                       : cudf::null_policy::INCLUDE);
 
@@ -549,43 +549,43 @@ RowVectorPtr CudfHashAggregation::doGroupByAggregation(
     aggregator->addGroupbyRequest(tbl->view(), requests);
   }
 
-  auto [group_keys, results] = group_by_owner.aggregate(requests, stream);
+  auto [groupKeys, results] = groupByOwner.aggregate(requests, stream);
   // flatten the results
-  std::vector<std::unique_ptr<cudf::column>> result_columns;
+  std::vector<std::unique_ptr<cudf::column>> resultColumns;
 
   // first fill the grouping keys
-  auto group_keys_columns = group_keys->release();
-  result_columns.insert(
-      result_columns.begin(),
-      std::make_move_iterator(group_keys_columns.begin()),
-      std::make_move_iterator(group_keys_columns.end()));
+  auto groupKeysColumns = groupKeys->release();
+  resultColumns.insert(
+      resultColumns.begin(),
+      std::make_move_iterator(groupKeysColumns.begin()),
+      std::make_move_iterator(groupKeysColumns.end()));
 
   // then fill the aggregation results
   for (auto& aggregator : aggregators_) {
-    result_columns.push_back(aggregator->makeOutputColumn(results, stream));
+    resultColumns.push_back(aggregator->makeOutputColumn(results, stream));
   }
 
   // make a cudf table out of columns
-  auto result_table = std::make_unique<cudf::table>(std::move(result_columns));
+  auto resultTable = std::make_unique<cudf::table>(std::move(resultColumns));
 
   // velox expects nullptr instead of a table with 0 rows
-  if (result_table->num_rows() == 0) {
+  if (resultTable->num_rows() == 0) {
     return nullptr;
   }
 
-  auto num_rows = result_table->num_rows();
+  auto numRows = resultTable->num_rows();
 
   return std::make_shared<cudf_velox::CudfVector>(
-      pool(), outputType_, num_rows, std::move(result_table), stream);
+      pool(), outputType_, numRows, std::move(resultTable), stream);
 }
 
 RowVectorPtr CudfHashAggregation::doGlobalAggregation(
     std::unique_ptr<cudf::table> tbl,
     rmm::cuda_stream_view stream) {
-  std::vector<std::unique_ptr<cudf::column>> result_columns;
-  result_columns.reserve(aggregators_.size());
+  std::vector<std::unique_ptr<cudf::column>> resultColumns;
+  resultColumns.reserve(aggregators_.size());
   for (auto i = 0; i < aggregators_.size(); i++) {
-    result_columns.push_back(aggregators_[i]->doReduce(
+    resultColumns.push_back(aggregators_[i]->doReduce(
         tbl->view(), outputType_->childAt(i), stream));
   }
 
@@ -593,27 +593,27 @@ RowVectorPtr CudfHashAggregation::doGlobalAggregation(
       pool(),
       outputType_,
       1,
-      std::make_unique<cudf::table>(std::move(result_columns)),
+      std::make_unique<cudf::table>(std::move(resultColumns)),
       stream);
 }
 
 RowVectorPtr CudfHashAggregation::getDistinctKeys(
     std::unique_ptr<cudf::table> tbl,
     rmm::cuda_stream_view stream) {
-  std::vector<cudf::size_type> key_indices(
+  std::vector<cudf::size_type> keyIndices(
       groupingKeyInputChannels_.begin(), groupingKeyInputChannels_.end());
   auto result = cudf::distinct(
       tbl->view(),
-      key_indices,
+      keyIndices,
       cudf::duplicate_keep_option::KEEP_FIRST,
       cudf::null_equality::EQUAL,
       cudf::nan_equality::ALL_EQUAL,
       stream);
 
-  auto num_rows = result->num_rows();
+  auto numRows = result->num_rows();
 
   return std::make_shared<cudf_velox::CudfVector>(
-      pool(), outputType_, num_rows, std::move(result), stream);
+      pool(), outputType_, numRows, std::move(result), stream);
 }
 
 RowVectorPtr CudfHashAggregation::getOutput() {

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -39,7 +39,7 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
 
     virtual std::unique_ptr<cudf::column> doReduce(
         cudf::table_view const& input,
-        TypePtr const& output_type,
+        TypePtr const& outputType,
         rmm::cuda_stream_view stream) = 0;
 
     virtual std::unique_ptr<cudf::column> makeOutputColumn(
@@ -52,9 +52,9 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
         cudf::aggregation::Kind kind,
         uint32_t inputIndex,
         VectorPtr constant,
-        bool is_global)
+        bool isGlobal)
         : step(step),
-          is_global(is_global),
+          is_global(isGlobal),
           kind(kind),
           inputIndex(inputIndex),
           constant(constant) {}

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -104,14 +104,14 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
   cudf::ast::tree tree_;
   std::vector<std::unique_ptr<cudf::scalar>> scalars_;
 
-  bool right_precomputed_{false};
+  bool rightPrecomputed_{false};
 
-  std::vector<cudf::size_type> left_key_indices_;
-  std::vector<cudf::size_type> right_key_indices_;
-  std::vector<cudf::size_type> left_column_indices_to_gather_;
-  std::vector<cudf::size_type> right_column_indices_to_gather_;
-  std::vector<size_t> left_column_output_indices_;
-  std::vector<size_t> right_column_output_indices_;
+  std::vector<cudf::size_type> leftKeyIndices_;
+  std::vector<cudf::size_type> rightKeyIndices_;
+  std::vector<cudf::size_type> leftColumnIndicesToGather_;
+  std::vector<cudf::size_type> rightColumnIndicesToGather_;
+  std::vector<size_t> leftColumnOutputIndices_;
+  std::vector<size_t> rightColumnOutputIndices_;
   bool finished_{false};
 };
 

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.h
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.h
@@ -42,25 +42,25 @@ struct PrecomputeInstruction {
         new_column_index(newIndex) {}
 };
 
-cudf::ast::expression const& create_ast_tree(
+cudf::ast::expression const& createAstTree(
     const std::shared_ptr<velox::exec::Expr>& expr,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const RowTypePtr& inputRowSchema,
-    std::vector<PrecomputeInstruction>& precompute_instructions);
+    std::vector<PrecomputeInstruction>& precomputeInstructions);
 
-cudf::ast::expression const& create_ast_tree(
+cudf::ast::expression const& createAstTree(
     const std::shared_ptr<velox::exec::Expr>& expr,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const RowTypePtr& leftRowSchema,
     const RowTypePtr& rightRowSchema,
-    std::vector<PrecomputeInstruction>& left_precompute_instructions,
-    std::vector<PrecomputeInstruction>& right_precompute_instructions);
+    std::vector<PrecomputeInstruction>& leftPrecomputeInstructions,
+    std::vector<PrecomputeInstruction>& rightPrecomputeInstructions);
 
 void addPrecomputedColumns(
-    std::vector<std::unique_ptr<cudf::column>>& input_table_columns,
-    const std::vector<PrecomputeInstruction>& precompute_instructions,
+    std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
+    const std::vector<PrecomputeInstruction>& precomputeInstructions,
     const std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     rmm::cuda_stream_view stream);
 
@@ -76,13 +76,13 @@ class ExpressionEvaluator {
 
   // Evaluates the expression tree for the given input columns
   std::vector<std::unique_ptr<cudf::column>> compute(
-      std::vector<std::unique_ptr<cudf::column>>& input_table_columns,
+      std::vector<std::unique_ptr<cudf::column>>& inputTableColumns,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr);
 
   void close();
 
-  static bool can_be_evaluated(
+  static bool canBeEvaluated(
       const std::vector<std::shared_ptr<velox::exec::Expr>>& exprs);
 
  private:
@@ -91,7 +91,7 @@ class ExpressionEvaluator {
   // instruction on dependent column to get new column index on non-ast
   // supported operations in expressions
   // <dependent_column_index, "instruction", new_column_index>
-  std::vector<PrecomputeInstruction> precompute_instructions_;
+  std::vector<PrecomputeInstruction> precomputeInstructions_;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/NvtxHelper.h
+++ b/velox/experimental/cudf/exec/NvtxHelper.h
@@ -28,12 +28,12 @@ class NvtxHelper {
   NvtxHelper(
       nvtx3::color color,
       std::optional<int64_t> payload = std::nullopt,
-      std::optional<std::string> extra_info = std::nullopt)
-      : color_(color), payload_(payload), extra_info_(extra_info) {}
+      std::optional<std::string> extraInfo = std::nullopt)
+      : color_(color), payload_(payload), extraInfo_(extraInfo) {}
 
   nvtx3::color color_{nvtx3::rgb{125, 125, 125}}; // Gray
   std::optional<int64_t> payload_{};
-  std::optional<std::string> extra_info_{};
+  std::optional<std::string> extraInfo_{};
 };
 
 /**
@@ -88,7 +88,7 @@ constexpr std::string_view extractClassAndFunction(
   static std::string const nvtx3_func_name__{                                    \
       std::string(extractClassAndFunction(__PRETTY_FUNCTION__))};                \
   std::string const nvtx3_func_extra_info__{                                     \
-      nvtx3_func_name__ + " " + this->extra_info_.value_or("")};                 \
+      nvtx3_func_name__ + " " + this->extraInfo_.value_or("")};                  \
   ::nvtx3::event_attributes const nvtx3_func_attr__{                           \
       this->payload_.has_value() ?                                             \
           ::nvtx3::event_attributes{nvtx3_func_extra_info__, this->color_,     \

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -101,7 +101,7 @@ bool CompileState::compile() {
   auto isFilterProjectSupported = [](const exec::Operator* op) {
     if (auto filterProjectOp = dynamic_cast<const exec::FilterProject*>(op)) {
       auto info = filterProjectOp->exprsAndProjection();
-      return ExpressionEvaluator::can_be_evaluated(info.exprs->exprs());
+      return ExpressionEvaluator::canBeEvaluated(info.exprs->exprs());
     }
     return false;
   };

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -36,7 +36,7 @@
 
 namespace facebook::velox::cudf_velox {
 
-cudf::type_id velox_to_cudf_type_id(const TypePtr& type) {
+cudf::type_id veloxToCudfTypeId(const TypePtr& type) {
   switch (type->kind()) {
     case TypeKind::BOOLEAN:
       return cudf::type_id::BOOL8;

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -26,7 +26,7 @@
 
 namespace facebook::velox::cudf_velox {
 
-cudf::type_id velox_to_cudf_type_id(const TypePtr& type);
+cudf::type_id veloxToCudfTypeId(const TypePtr& type);
 
 namespace with_arrow {
 

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -29,10 +29,7 @@ using namespace facebook::velox::common::testutil;
 namespace {
 
 template <typename T>
-T get_col_value(
-    const std::vector<RowVectorPtr>& input,
-    int col,
-    int32_t index) {
+T getColValue(const std::vector<RowVectorPtr>& input, int col, int32_t index) {
   return input[0]->as<RowVector>()->childAt(col)->as<FlatVector<T>>()->valueAt(
       index);
 }
@@ -266,7 +263,7 @@ class CudfFilterProjectTest : public OperatorTestBase {
 
   void testMultiInputAndOperation(const std::vector<RowVectorPtr>& input) {
     // Create a plan with multiple AND operations
-    auto c2Value = get_col_value<StringView>(input, 2, 1).str();
+    auto c2Value = getColValue<StringView>(input, 2, 1).str();
     auto plan = PlanBuilder()
                     .values(input)
                     .project(
@@ -283,7 +280,7 @@ class CudfFilterProjectTest : public OperatorTestBase {
 
   void testMultiInputOrOperation(const std::vector<RowVectorPtr>& input) {
     // Create a plan with multiple OR operations
-    auto c2Value = get_col_value<StringView>(input, 2, 1).str();
+    auto c2Value = getColValue<StringView>(input, 2, 1).str();
     auto plan = PlanBuilder()
                     .values(input)
                     .project(
@@ -302,7 +299,7 @@ class CudfFilterProjectTest : public OperatorTestBase {
     // Create a plan with an IN operation for integers
     std::vector<int32_t> c0Values;
     for (int32_t i = 0; i < 5; i++) {
-      c0Values.push_back(get_col_value<int32_t>(input, 0, i));
+      c0Values.push_back(getColValue<int32_t>(input, 0, i));
     }
     std::string c0ValuesStr;
     for (size_t i = 0; i < c0Values.size(); ++i) {
@@ -322,7 +319,7 @@ class CudfFilterProjectTest : public OperatorTestBase {
     // Create a plan with an IN operation for doubles
     std::vector<double> c1Values;
     for (int32_t i = 0; i < 4; i++) {
-      c1Values.push_back(get_col_value<double>(input, 1, i));
+      c1Values.push_back(getColValue<double>(input, 1, i));
     }
     std::string c1ValuesStr;
     for (size_t i = 0; i < c1Values.size(); ++i) {
@@ -342,7 +339,7 @@ class CudfFilterProjectTest : public OperatorTestBase {
     // Create a plan with an IN operation for strings
     std::vector<StringView> c2Values;
     for (int32_t i = 0; i < 3; i++) {
-      c2Values.push_back(get_col_value<StringView>(input, 2, i));
+      c2Values.push_back(getColValue<StringView>(input, 2, i));
     }
     std::string c2ValuesStr;
     for (size_t i = 0; i < c2Values.size(); ++i) {

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -44,7 +44,7 @@ namespace {
 struct TestParam {
   int numDrivers;
 
-  explicit TestParam(int _numDrivers) : numDrivers(_numDrivers) {}
+  explicit TestParam(int numDrivers) : numDrivers(numDrivers) {}
 };
 
 using SplitInput =
@@ -240,11 +240,11 @@ class HashJoinBuilder {
   HashJoinBuilder& planNode(core::PlanNodePtr planNode) {
     VELOX_CHECK_NULL(planNode_);
     planNode_ = planNode;
-    auto hash_node_ptr = core::PlanNode::findFirstNode(
+    auto hashNodePtr = core::PlanNode::findFirstNode(
         planNode.get(), [](const core::PlanNode* node) {
           return dynamic_cast<const core::HashJoinNode*>(node) != nullptr;
         });
-    if (cudf_velox::cudfDebugEnabled() && hash_node_ptr != nullptr) {
+    if (cudf_velox::cudfDebugEnabled() && hashNodePtr != nullptr) {
       std::cout << "Found a HashJoinNode" << std::endl;
     }
     return *this;

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -106,7 +106,7 @@ FOLLY_ALWAYS_INLINE std::ostream& operator<<(std::ostream& os, TestMode mode) {
 struct TestParam {
   uint64_t value;
 
-  explicit TestParam(uint64_t _value) : value(_value) {}
+  explicit TestParam(uint64_t value) : value(value) {}
 
   TestParam(
       FileFormat fileFormat,

--- a/velox/experimental/cudf/tests/utils/ParquetConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/ParquetConnectorTestBase.cpp
@@ -289,7 +289,7 @@ ParquetConnectorTestBase::makeParquetInsertTableHandle(
         std::make_shared<connector::parquet::ParquetColumnHandle>(
             tableColumnNames.at(i),
             tableColumnTypes.at(i),
-            cudf::data_type{velox_to_cudf_type_id(tableColumnTypes.at(i))}));
+            cudf::data_type{veloxToCudfTypeId(tableColumnTypes.at(i))}));
   }
 
   return std::make_shared<connector::parquet::ParquetInsertTableHandle>(


### PR DESCRIPTION
This PR includes changes from manually running clang-tidy with rules from velox/experimental/cudf/.clang-tidy. 