### PR TITLE
add batching in CudfToVelox

### DIFF
--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -25,6 +25,7 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
 
+#include <cudf/copying.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
@@ -173,6 +174,11 @@ CudfToVelox::CudfToVelox(
           operatorId,
           fmt::format("[{}]", planNodeId)) {}
 
+bool CudfToVelox::isPassthroughMode() const {
+  return operatorCtx_->driverCtx()->queryConfig().get<bool>(
+      kPassthroughMode, true);
+}
+
 void CudfToVelox::addInput(RowVectorPtr input) {
   // Accumulate inputs
   if (input->size() > 0) {
@@ -182,6 +188,13 @@ void CudfToVelox::addInput(RowVectorPtr input) {
   }
 }
 
+std::optional<uint64_t> CudfToVelox::averageRowSize() {
+  if (!averageRowSize_) {
+    averageRowSize_ = inputs_.front()->estimateFlatSize() / inputs_.front()->size();
+  }
+  return averageRowSize_;
+}
+
 RowVectorPtr CudfToVelox::getOutput() {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
   if (finished_ || inputs_.empty()) {
@@ -189,16 +202,96 @@ RowVectorPtr CudfToVelox::getOutput() {
     return nullptr;
   }
 
+  // Get the target batch size
+  const auto targetBatchSize = outputBatchRows(averageRowSize());
   auto stream = inputs_.front()->stream();
-  std::unique_ptr<cudf::table> tbl = inputs_.front()->release();
-  inputs_.pop_front();
 
-  VELOX_CHECK_NOT_NULL(tbl);
-  if (tbl->num_rows() == 0) {
+  // Process single input directly in these cases:
+  // 1. In passthrough mode
+  // 2. If we only have one input and it's smaller than or equal to the target batch size
+  if (isPassthroughMode()
+     || (inputs_.size() == 1 && inputs_.front()->size() <= targetBatchSize)) {
+    std::unique_ptr<cudf::table> tbl = inputs_.front()->release();
+    inputs_.pop_front();
+
+    VELOX_CHECK_NOT_NULL(tbl);
+    if (tbl->num_rows() == 0) {
+      finished_ = noMoreInput_ && inputs_.empty();
+      return nullptr;
+    }
+    RowVectorPtr output =
+        with_arrow::toVeloxColumn(tbl->view(), pool(), "", stream);
+    stream.synchronize();
+    finished_ = noMoreInput_ && inputs_.empty();
+    output->setType(outputType_);
+    return output;
+  }
+
+  // Calculate how many tables we need to concatenate to reach the target batch size
+  // and collect them in a vector
+  std::vector<CudfVectorPtr> selectedInputs;
+  vector_size_t totalSize = 0;
+  
+  while (!inputs_.empty() && totalSize < targetBatchSize) {
+    auto& input = inputs_.front();
+    if (totalSize + input->size() <= targetBatchSize) {
+      totalSize += input->size();
+      selectedInputs.push_back(std::move(input));
+      inputs_.pop_front();
+    } else {
+      // If the next input would exceed targetBatchSize, 
+      // we need to split it and only take what we need
+      auto cudfTableView = input->getTableView();
+      auto partitions = std::vector<cudf::size_type>{
+          static_cast<cudf::size_type>(targetBatchSize - totalSize)};
+      auto tableSplits = cudf::split(cudfTableView, partitions);
+      
+      // Create new CudfVector from the first part
+      auto firstPart = std::make_unique<cudf::table>(tableSplits[0], stream);
+      auto firstPartSize = firstPart->num_rows();
+      auto firstPartVector = std::make_shared<CudfVector>(
+          pool(), input->type(), firstPartSize, std::move(firstPart), stream);
+      
+      // Create new CudfVector from the second part
+      auto secondPart = std::make_unique<cudf::table>(tableSplits[1], stream);
+      auto secondPartSize = secondPart->num_rows();
+      auto secondPartVector = std::make_shared<CudfVector>(
+          pool(), input->type(), secondPartSize, std::move(secondPart), stream);
+      
+      // Replace the original input with the second part
+      input = std::move(secondPartVector);
+      
+      // Add the first part to selectedInputs
+      selectedInputs.push_back(std::move(firstPartVector));
+      totalSize += firstPartSize;
+      break;
+    }
+  }
+
+  finished_ = noMoreInput_ && inputs_.empty();
+
+  // If we have no inputs to process, return nullptr
+  if (selectedInputs.empty()) {
     return nullptr;
   }
+
+  // Concatenate the selected tables on the GPU
+  std::unique_ptr<cudf::table> resultTable;
+  if (selectedInputs.size() == 1) {
+    resultTable = selectedInputs[0]->release();
+  } else {
+    resultTable = getConcatenatedTable(selectedInputs, stream);
+  }
+
+  // Convert the concatenated table to a RowVector
+  const auto size = resultTable->num_rows();
+  VELOX_CHECK_NOT_NULL(resultTable);
+  if (size == 0) {
+    return nullptr;
+  }
+
   RowVectorPtr output =
-      with_arrow::toVeloxColumn(tbl->view(), pool(), "", stream);
+      with_arrow::toVeloxColumn(resultTable->view(), pool(), "", stream);
   stream.synchronize();
   finished_ = noMoreInput_ && inputs_.empty();
   output->setType(outputType_);

--- a/velox/experimental/cudf/exec/CudfConversion.h
+++ b/velox/experimental/cudf/exec/CudfConversion.h
@@ -66,6 +66,9 @@ class CudfFromVelox : public exec::Operator, public NvtxHelper {
 
 class CudfToVelox : public exec::Operator, public NvtxHelper {
  public:
+  static constexpr const char* kPassthroughMode =
+      "velox.cudf.to_velox.passthrough_mode";
+
   CudfToVelox(
       int32_t operatorId,
       RowTypePtr outputType,
@@ -91,6 +94,9 @@ class CudfToVelox : public exec::Operator, public NvtxHelper {
   void close() override;
 
  private:
+  bool isPassthroughMode() const;
+  std::optional<uint64_t> averageRowSize();
+  std::optional<uint64_t> averageRowSize_;
   std::deque<CudfVectorPtr> inputs_;
   bool finished_ = false;
 };

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -22,6 +22,8 @@
 #include "velox/exec/Task.h"
 
 #include <cudf/copying.hpp>
+#include <cudf/join/join.hpp>
+#include <cudf/join/mixed_join.hpp>
 
 #include <nvtx3/nvtx3.hpp>
 

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -25,7 +25,8 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
 
-#include <cudf/join.hpp>
+#include <cudf/ast/expressions.hpp>
+#include <cudf/join/hash_join.hpp>
 #include <cudf/table/table.hpp>
 
 namespace facebook::velox::cudf_velox {

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/CudfConversion.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryConfig.h"
@@ -316,5 +317,73 @@ TEST_F(OrderByTest, varfields) {
 
   testSingleKey(vectors, "c2");
 }
+
+/// Verifies output batch rows of OrderBy
+TEST_F(OrderByTest, outputBatchRows) {
+  struct {
+    int numRowsPerBatch;
+    int preferredOutBatchBytes;
+    int maxOutBatchRows;
+    int expectedOutputVectors;
+
+    // TODO: add output size check with spilling enabled
+    std::string debugString() const {
+      return fmt::format(
+          "numRowsPerBatch:{}, preferredOutBatchBytes:{}, maxOutBatchRows:{}, expectedOutputVectors:{}",
+          numRowsPerBatch,
+          preferredOutBatchBytes,
+          maxOutBatchRows,
+          expectedOutputVectors);
+    }
+  } testSettings[] = {
+      {1024, 1, 100, 1024},
+      // estimated size per row is ~2092, set preferredOutBatchBytes to 20920,
+      // so each batch has 10 rows, so it would return 100 batches
+      {1000, 20920, 100, 100},
+      // same as above, but maxOutBatchRows is 1, so it would return 1000
+      // batches
+      {1000, 20920, 1, 1000}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    const vector_size_t batchSize = testData.numRowsPerBatch;
+    std::vector<RowVectorPtr> rowVectors;
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](vector_size_t row) { return row; }, nullEvery(5));
+    auto c1 = makeFlatVector<double>(
+        batchSize, [&](vector_size_t row) { return row; }, nullEvery(11));
+    std::vector<VectorPtr> vectors;
+    vectors.push_back(c0);
+    for (int i = 0; i < 256; ++i) {
+      vectors.push_back(c1);
+    }
+    rowVectors.push_back(makeRowVector(vectors));
+    createDuckDbTable(rowVectors);
+
+    core::PlanNodeId orderById;
+    auto plan = PlanBuilder()
+                    .values(rowVectors)
+                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                    .capturePlanNodeId(orderById)
+                    .planNode();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    queryCtx->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kPreferredOutputBatchBytes,
+          std::to_string(testData.preferredOutBatchBytes)},
+         {core::QueryConfig::kMaxOutputBatchRows,
+          std::to_string(testData.maxOutBatchRows)},
+          {facebook::velox::cudf_velox::CudfToVelox::kPassthroughMode, "false"}});
+    CursorParameters params;
+    params.planNode = plan;
+    params.queryCtx = queryCtx;
+    auto task = assertQueryOrdered(
+        params, "SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST", {0});
+    
+    EXPECT_EQ(
+        testData.expectedOutputVectors,
+        toPlanStats(task->taskStats()).at(orderById + "-to-velox").outputVectors);
+  }
+}
+
 
 } // namespace

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryConfig.h"
@@ -372,18 +372,20 @@ TEST_F(OrderByTest, outputBatchRows) {
           std::to_string(testData.preferredOutBatchBytes)},
          {core::QueryConfig::kMaxOutputBatchRows,
           std::to_string(testData.maxOutBatchRows)},
-          {facebook::velox::cudf_velox::CudfToVelox::kPassthroughMode, "false"}});
+         {facebook::velox::cudf_velox::CudfToVelox::kPassthroughMode,
+          "false"}});
     CursorParameters params;
     params.planNode = plan;
     params.queryCtx = queryCtx;
     auto task = assertQueryOrdered(
         params, "SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST", {0});
-    
+
     EXPECT_EQ(
         testData.expectedOutputVectors,
-        toPlanStats(task->taskStats()).at(orderById + "-to-velox").outputVectors);
+        toPlanStats(task->taskStats())
+            .at(orderById + "-to-velox")
+            .outputVectors);
   }
 }
-
 
 } // namespace


### PR DESCRIPTION
This PR adds batching for Velox vectors created from CudfToVelox with sizes as per config, and `Operator::outputBatchRows(averageRowSize)`
- add batching in CudfToVelox
- Enable  OrderByTest.outputBatchRows unit test (test updated to look for stats of CudfToVelox id)
