### PR TITLE
Add debug utility function to print the cudf table

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   CudfLimit.cpp
   CudfLocalPartition.cpp
   CudfOrderBy.cpp
+  DebugUtil.cpp
   ExpressionEvaluator.cpp
   ToCudf.cpp
   Utilities.cpp

--- a/velox/experimental/cudf/exec/DebugUtil.cpp
+++ b/velox/experimental/cudf/exec/DebugUtil.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/DebugUtil.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
+namespace facebook::velox::cudf_velox {
+
+std::string DebugUtil::toString(
+    const cudf::table_view& table,
+    vector_size_t from,
+    vector_size_t to) {
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto rowVector = with_arrow::toVeloxColumn(table, pool_.get(), "", stream);
+  stream.synchronize();
+  return rowVector->toString(from, to);
+}
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DebugUtil.cpp
+++ b/velox/experimental/cudf/exec/DebugUtil.cpp
@@ -26,6 +26,7 @@ std::string DebugUtil::toString(
     vector_size_t from,
     vector_size_t to) {
   auto rowVector = with_arrow::toVeloxColumn(table, pool_.get(), "", stream);
+  stream.synchronize();
   return rowVector->toString(from, to);
 }
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DebugUtil.cpp
+++ b/velox/experimental/cudf/exec/DebugUtil.cpp
@@ -22,11 +22,10 @@ namespace facebook::velox::cudf_velox {
 
 std::string DebugUtil::toString(
     const cudf::table_view& table,
+    rmm::cuda_stream_view stream,
     vector_size_t from,
     vector_size_t to) {
-  auto stream = cudfGlobalStreamPool().get_stream();
   auto rowVector = with_arrow::toVeloxColumn(table, pool_.get(), "", stream);
-  stream.synchronize();
   return rowVector->toString(from, to);
 }
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DebugUtil.h
+++ b/velox/experimental/cudf/exec/DebugUtil.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+namespace facebook::velox::cudf_velox {
+class DebugUtil {
+ public:
+  std::string
+  toString(const cudf::table_view& table, vector_size_t from, vector_size_t to);
+
+ private:
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      rootPool_->addLeafChild("debug_util")};
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/DebugUtil.h
+++ b/velox/experimental/cudf/exec/DebugUtil.h
@@ -21,8 +21,11 @@
 namespace facebook::velox::cudf_velox {
 class DebugUtil {
  public:
-  std::string
-  toString(const cudf::table_view& table, vector_size_t from, vector_size_t to);
+  std::string toString(
+      const cudf::table_view& table,
+      rmm::cuda_stream_view stream,
+      vector_size_t from,
+      vector_size_t to);
 
  private:
   std::shared_ptr<memory::MemoryPool> rootPool_{


### PR DESCRIPTION
The cudf table helper function toString is in https://github.com/rapidsai/cudf/blob/branch-25.06/cpp/include/cudf_test/debug_utilities.hpp, but it exists in test library, it's not graceful to add a test library, so convert it to velox cpu RowVector and then print any information you need. 

This function is helpful in result mismatch debug.