### PR TITLE
Fix replacement of localexchange when followed by non-cudf operator

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -256,6 +256,9 @@ bool CompileState::compile() {
       replaceOp.push_back(
           std::make_unique<CudfLocalPartition>(id, ctx, planNode));
       replaceOp.back()->initialize();
+    } else if (
+        auto localExchangeOp = dynamic_cast<exec::LocalExchange*>(oper)) {
+      keepOperator = 1;
     }
 
     if (producesGpuOutput(oper) and


### PR DESCRIPTION
Due to a bug in `cudfAdapter`, when local partition node is followed by a non-cudf node, a `CudfToVelox` operator was **replacing** the `LocalExchange` at the beginning of the post partition pipeline.

Before:
```
Operators before adapting for cuDF: count [4]
  Operator: ID 0: LocalExchange(0)
  Operator: ID 1: TopN[4] 1
  Operator: ID 2: PartitionedOutput[5] 2
  Operator: ID 3: CallbackSink[N/A] 3
Operators after adapting for cuDF: count [4]
  Operator: ID 0: CudfToVelox[3-to-velox] 0  <<<<======= LocalExchange removed!
  Operator: ID 1: TopN[4] 1
  Operator: ID 2: PartitionedOutput[5] 2
  Operator: ID 3: CallbackSink[N/A] 3
```

After
```
Operators before adapting for cuDF: count [4]
  Operator: ID 0: LocalExchange(0)
  Operator: ID 1: TopN[4] 1
  Operator: ID 2: PartitionedOutput[5] 2
  Operator: ID 3: CallbackSink[N/A] 3
Operators after adapting for cuDF: count [5]
  Operator: ID 0: LocalExchange(0)
  Operator: ID 1: CudfToVelox[3-to-velox] 1
  Operator: ID 2: TopN[4] 2
  Operator: ID 3: PartitionedOutput[5] 3
  Operator: ID 4: CallbackSink[N/A] 4
```