### PR TITLE
Fix HashAggregation result type

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -34,10 +34,6 @@ namespace {
 
 using namespace facebook::velox;
 
-bool isFloatingPointType(const TypePtr& type) {
-  return type->kind() != TypeKind::REAL && type->kind() != TypeKind::DOUBLE;
-}
-
 #define DEFINE_SIMPLE_AGGREGATOR(Name, name, KIND)                            \
   struct Name##Aggregator : cudf_velox::CudfHashAggregation::Aggregator {     \
     Name##Aggregator(                                                         \
@@ -73,7 +69,7 @@ bool isFloatingPointType(const TypePtr& type) {
       auto col = std::move(results[output_idx].results[0]);                   \
       const auto cudfType =                                                   \
           cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));         \
-      if (col->type() != cudfType && !isFloatingPointType(resultType)) {      \
+      if (col->type() != cudfType) {                                          \
         col = cudf::cast(*col, cudfType, stream);                             \
       }                                                                       \
       return col;                                                             \
@@ -831,9 +827,8 @@ CudfVectorPtr CudfHashAggregation::doGlobalAggregation(
   std::vector<std::unique_ptr<cudf::column>> resultColumns;
   resultColumns.reserve(aggregators_.size());
   for (auto i = 0; i < aggregators_.size(); i++) {
-    resultColumns.push_back(
-        aggregators_[i]->doReduce(
-            tbl->view(), outputType_->childAt(i), stream));
+    resultColumns.push_back(aggregators_[i]->doReduce(
+      tbl->view(), outputType_->childAt(i), stream));
   }
 
   return std::make_shared<cudf_velox::CudfVector>(

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -567,11 +567,15 @@ auto toIntermediateAggregators(
     }
     const auto originalName = getOriginalName(kind);
     auto const companionStep = getCompanionStep(kind, step);
-    const auto resultType = exec::isPartialOutput(companionStep)
-        ? exec::Aggregate::intermediateType(originalName, argumentTypes)
-        : outputType->childAt(i);
-    aggregators.push_back(createAggregator(
-        step, kind, inputIndex, constant, isGlobal, resultType));
+    if (exec::isPartialOutput(companionStep)) {
+      const auto resultType =
+          exec::Aggregate::intermediateType(originalName, argumentTypes);
+      aggregators.push_back(createAggregator(
+          step, kind, inputIndex, constant, isGlobal, resultType));
+    } else {
+      // Final step aggregator will not use the intermediate aggregator.
+      aggregators.push_back(nullptr);
+    }
   }
   return aggregators;
 }

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -40,13 +40,15 @@ using namespace facebook::velox;
         core::AggregationNode::Step step,                                     \
         uint32_t inputIndex,                                                  \
         VectorPtr constant,                                                   \
-        bool is_global)                                                       \
+        bool is_global,                                                       \
+        const TypePtr& resultType)                                            \
         : Aggregator(                                                         \
               step,                                                           \
               cudf::aggregation::KIND,                                        \
               inputIndex,                                                     \
               constant,                                                       \
-              is_global) {}                                                   \
+              is_global,                                                      \
+              resultType) {}                                                  \
                                                                               \
     void addGroupbyRequest(                                                   \
         cudf::table_view const& tbl,                                          \
@@ -64,7 +66,13 @@ using namespace facebook::velox;
     std::unique_ptr<cudf::column> makeOutputColumn(                           \
         std::vector<cudf::groupby::aggregation_result>& results,              \
         rmm::cuda_stream_view stream) override {                              \
-      return std::move(results[output_idx].results[0]);                       \
+      auto col = std::move(results[output_idx].results[0]);                   \
+      const auto cudfType =                                                   \
+          cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));         \
+      if (col->type() != cudfType) {                                          \
+        col = cudf::cast(*col, cudfType, stream);                             \
+      }                                                                       \
+      return col;                                                             \
     }                                                                         \
                                                                               \
     std::unique_ptr<cudf::column> doReduce(                                   \
@@ -93,13 +101,15 @@ struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       core::AggregationNode::Step step,
       uint32_t inputIndex,
       VectorPtr constant,
-      bool isGlobal)
+      bool isGlobal,
+      const TypePtr& resultType)
       : Aggregator(
             step,
             cudf::aggregation::COUNT_VALID,
             inputIndex,
             constant,
-            isGlobal) {}
+            isGlobal,
+            resultType) {}
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
@@ -149,8 +159,10 @@ struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       rmm::cuda_stream_view stream) override {
     // cudf produces int32 for count(0) but velox expects int64
     auto col = std::move(results[outputIdx_].results[0]);
-    if (col->type() == cudf::data_type(cudf::type_id::INT32)) {
-      col = cudf::cast(*col, cudf::data_type(cudf::type_id::INT64), stream);
+    const auto cudfOutputType =
+        cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));
+    if (col->type() != cudfOutputType) {
+      col = cudf::cast(*col, cudfOutputType, stream);
     }
     return col;
   }
@@ -164,13 +176,15 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
       core::AggregationNode::Step step,
       uint32_t inputIndex,
       VectorPtr constant,
-      bool isGlobal)
+      bool isGlobal,
+      const TypePtr& resultType)
       : Aggregator(
             step,
             cudf::aggregation::MEAN,
             inputIndex,
             constant,
-            isGlobal) {}
+            isGlobal,
+            resultType) {}
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
@@ -223,6 +237,7 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
   std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,
       rmm::cuda_stream_view stream) override {
+    const auto& outputType = asRowType(resultType);
     switch (step) {
       case core::AggregationNode::Step::kSingle:
         return std::move(results[meanIdx_].results[0]);
@@ -231,13 +246,20 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
         auto count = std::move(results[sumIdx_].results[1]);
 
         auto const size = sum->size();
-
-        auto countInt64 =
-            cudf::cast(*count, cudf::data_type(cudf::type_id::INT64), stream);
+        auto const cudfSumType = cudf::data_type(
+            cudf_velox::veloxToCudfTypeId(outputType->childAt(0)));
+        auto const cudfCountType = cudf::data_type(
+            cudf_velox::veloxToCudfTypeId(outputType->childAt(1)));
+        if (sum->type() != cudf::data_type(cudfSumType)) {
+          sum = cudf::cast(*sum, cudf::data_type(cudfSumType), stream);
+        }
+        if (count->type() != cudf::data_type(cudfCountType)) {
+          count = cudf::cast(*count, cudf::data_type(cudfCountType), stream);
+        }
 
         auto children = std::vector<std::unique_ptr<cudf::column>>();
         children.push_back(std::move(sum));
-        children.push_back(std::move(countInt64));
+        children.push_back(std::move(count));
 
         // TODO: Handle nulls. This can happen if all values are null in a
         // group.
@@ -260,6 +282,16 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
         auto count = std::move(results[countIdx_].results[0]);
 
         auto size = sum->size();
+        auto const cudfSumType = cudf::data_type(
+            cudf_velox::veloxToCudfTypeId(outputType->childAt(0)));
+        auto const cudfCountType = cudf::data_type(
+            cudf_velox::veloxToCudfTypeId(outputType->childAt(1)));
+        if (sum->type() != cudf::data_type(cudfSumType)) {
+          sum = cudf::cast(*sum, cudf::data_type(cudfSumType), stream);
+        }
+        if (count->type() != cudf::data_type(cudfCountType)) {
+          count = cudf::cast(*count, cudf::data_type(cudfCountType), stream);
+        }
 
         auto children = std::vector<std::unique_ptr<cudf::column>>();
         children.push_back(std::move(sum));
@@ -280,9 +312,7 @@ struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
             *sum,
             *count,
             cudf::binary_operator::DIV,
-            // TODO: Change the output type to be dependent on the input type
-            // like in the cudf groupby implementation.
-            cudf::data_type(cudf::type_id::FLOAT64),
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType)),
             stream);
         return avg;
       }
@@ -391,22 +421,23 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
     std::string const& kind,
     uint32_t inputIndex,
     VectorPtr constant,
-    bool isGlobal) {
+    bool isGlobal,
+    const TypePtr& resultType) {
   if (kind.rfind("sum", 0) == 0) {
     return std::make_unique<SumAggregator>(
-        step, inputIndex, constant, isGlobal);
+        step, inputIndex, constant, isGlobal, resultType);
   } else if (kind.rfind("count", 0) == 0) {
     return std::make_unique<CountAggregator>(
-        step, inputIndex, constant, isGlobal);
+        step, inputIndex, constant, isGlobal, resultType);
   } else if (kind.rfind("min", 0) == 0) {
     return std::make_unique<MinAggregator>(
-        step, inputIndex, constant, isGlobal);
+        step, inputIndex, constant, isGlobal, resultType);
   } else if (kind.rfind("max", 0) == 0) {
     return std::make_unique<MaxAggregator>(
-        step, inputIndex, constant, isGlobal);
+        step, inputIndex, constant, isGlobal, resultType);
   } else if (kind.rfind("avg", 0) == 0) {
     return std::make_unique<MeanAggregator>(
-        step, inputIndex, constant, isGlobal);
+        step, inputIndex, constant, isGlobal, resultType);
   } else {
     VELOX_NYI("Aggregation not yet supported");
   }
@@ -438,6 +469,15 @@ core::AggregationNode::Step getCompanionStep(
   return step;
 }
 
+std::string getOriginalName(std::string const& kind) {
+  for (const auto& [k, v] : companionStep) {
+    if (folly::StringPiece(kind).endsWith(k)) {
+      return kind.substr(0, kind.length() - k.length());
+    }
+  }
+  return kind;
+}
+
 bool hasFinalAggs(
     std::vector<core::AggregationNode::Aggregate> const& aggregates) {
   return std::any_of(aggregates.begin(), aggregates.end(), [](auto const& agg) {
@@ -457,7 +497,9 @@ auto toAggregators(
   for (auto const& aggregate : aggregationNode.aggregates()) {
     std::vector<column_index_t> aggInputs;
     std::vector<VectorPtr> aggConstants;
+    std::vector<TypePtr> argumentTypes;
     for (auto const& arg : aggregate.call->inputs()) {
+      argumentTypes.push_back(arg->type());
       if (auto const field =
               dynamic_cast<core::FieldAccessTypedExpr const*>(arg.get())) {
         aggInputs.push_back(inputRowSchema->getChildIdx(field->name()));
@@ -485,8 +527,12 @@ auto toAggregators(
     auto const inputIndex = aggInputs[0];
     auto const constant = aggConstants.empty() ? nullptr : aggConstants[0];
     auto const companionStep = getCompanionStep(kind, step);
-    aggregators.push_back(
-        createAggregator(companionStep, kind, inputIndex, constant, isGlobal));
+    const auto originalName = getOriginalName(kind);
+    const auto resultType = exec::isPartialOutput(companionStep)
+        ? exec::Aggregate::intermediateType(originalName, argumentTypes)
+        : exec::Aggregate::finalType(originalName, argumentTypes);
+    aggregators.push_back(createAggregator(
+        companionStep, kind, inputIndex, constant, isGlobal, resultType));
   }
   return aggregators;
 }
@@ -507,8 +553,15 @@ auto toIntermediateAggregators(
     auto const inputIndex = aggregationNode.groupingKeys().size() + i;
     auto const kind = aggregate.call->name();
     auto const constant = nullptr;
-    aggregators.push_back(
-        createAggregator(step, kind, inputIndex, constant, isGlobal));
+    std::vector<TypePtr> argumentTypes;
+    for (auto const& arg : aggregate.call->inputs()) {
+      argumentTypes.push_back(arg->type());
+    }
+    const auto originalName = getOriginalName(kind);
+    const auto resultType =
+        exec::Aggregate::finalType(originalName, argumentTypes);
+    aggregators.push_back(createAggregator(
+        step, kind, inputIndex, constant, isGlobal, resultType));
   }
   return aggregators;
 }
@@ -770,8 +823,9 @@ CudfVectorPtr CudfHashAggregation::doGlobalAggregation(
   std::vector<std::unique_ptr<cudf::column>> resultColumns;
   resultColumns.reserve(aggregators_.size());
   for (auto i = 0; i < aggregators_.size(); i++) {
-    resultColumns.push_back(aggregators_[i]->doReduce(
-        tbl->view(), outputType_->childAt(i), stream));
+    resultColumns.push_back(
+        aggregators_[i]->doReduce(
+            tbl->view(), outputType_->childAt(i), stream));
   }
 
   return std::make_shared<cudf_velox::CudfVector>(

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -491,20 +491,19 @@ bool hasFinalAggs(
 
 auto toAggregators(
     core::AggregationNode const& aggregationNode,
-    exec::OperatorCtx const& operatorCtx,
-    const RowTypePtr& outputType) {
+    exec::OperatorCtx const& operatorCtx) {
   auto const step = aggregationNode.step();
   bool const isGlobal = aggregationNode.groupingKeys().empty();
   auto const& inputRowSchema = aggregationNode.sources()[0]->outputType();
+  const auto numKeys = aggregationNode.groupingKeys().size();
+  const auto outputType = aggregationNode.outputType();
 
   std::vector<std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator>>
       aggregators;
   for (auto const& aggregate : aggregationNode.aggregates()) {
     std::vector<column_index_t> aggInputs;
     std::vector<VectorPtr> aggConstants;
-    std::vector<TypePtr> argumentTypes;
     for (auto const& arg : aggregate.call->inputs()) {
-      argumentTypes.push_back(arg->type());
       if (auto const field =
               dynamic_cast<core::FieldAccessTypedExpr const*>(arg.get())) {
         aggInputs.push_back(inputRowSchema->getChildIdx(field->name()));
@@ -534,10 +533,10 @@ auto toAggregators(
     auto const companionStep = getCompanionStep(kind, step);
     const auto originalName = getOriginalName(kind);
     const auto resultType = exec::isPartialOutput(companionStep)
-        ? exec::Aggregate::intermediateType(originalName, argumentTypes)
-        : outputType->childAt(i);
+        ? exec::Aggregate::intermediateType(
+              originalName, aggregate.rawInputTypes)
+        : outputType->childAt(numKeys + i);
 
-    // const auto resultType = outputType->childAt(i);
     aggregators.push_back(createAggregator(
         companionStep, kind, inputIndex, constant, isGlobal, resultType));
   }
@@ -546,8 +545,7 @@ auto toAggregators(
 
 auto toIntermediateAggregators(
     core::AggregationNode const& aggregationNode,
-    exec::OperatorCtx const& operatorCtx,
-    const RowTypePtr& outputType) {
+    exec::OperatorCtx const& operatorCtx) {
   auto const step = core::AggregationNode::Step::kIntermediate;
   bool const isGlobal = aggregationNode.groupingKeys().empty();
   auto const& inputRowSchema = aggregationNode.outputType();
@@ -561,15 +559,11 @@ auto toIntermediateAggregators(
     auto const inputIndex = aggregationNode.groupingKeys().size() + i;
     auto const kind = aggregate.call->name();
     auto const constant = nullptr;
-    std::vector<TypePtr> argumentTypes;
-    for (auto const& arg : aggregate.call->inputs()) {
-      argumentTypes.push_back(arg->type());
-    }
     const auto originalName = getOriginalName(kind);
     auto const companionStep = getCompanionStep(kind, step);
     if (exec::isPartialOutput(companionStep)) {
-      const auto resultType =
-          exec::Aggregate::intermediateType(originalName, argumentTypes);
+      const auto resultType = exec::Aggregate::intermediateType(
+          originalName, aggregate.rawInputTypes);
       aggregators.push_back(createAggregator(
           step, kind, inputIndex, constant, isGlobal, resultType));
     } else {
@@ -627,9 +621,9 @@ void CudfHashAggregation::initialize() {
   // We're postponing this for now.
 
   numAggregates_ = aggregationNode_->aggregates().size();
-  aggregators_ = toAggregators(*aggregationNode_, *operatorCtx_, outputType_);
+  aggregators_ = toAggregators(*aggregationNode_, *operatorCtx_);
   intermediateAggregators_ =
-      toIntermediateAggregators(*aggregationNode_, *operatorCtx_, outputType_);
+      toIntermediateAggregators(*aggregationNode_, *operatorCtx_);
 
   // Check that aggregate result type match the output type.
   // TODO: This is output schema validation. In velox CPU, it's done using

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -34,6 +34,10 @@ namespace {
 
 using namespace facebook::velox;
 
+bool isFloatingPointType(const TypePtr& type) {
+  return type->kind() != TypeKind::REAL && type->kind() != TypeKind::DOUBLE;
+}
+
 #define DEFINE_SIMPLE_AGGREGATOR(Name, name, KIND)                            \
   struct Name##Aggregator : cudf_velox::CudfHashAggregation::Aggregator {     \
     Name##Aggregator(                                                         \
@@ -69,7 +73,7 @@ using namespace facebook::velox;
       auto col = std::move(results[output_idx].results[0]);                   \
       const auto cudfType =                                                   \
           cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));         \
-      if (col->type() != cudfType) {                                          \
+      if (col->type() != cudfType && !isFloatingPointType(resultType)) {      \
         col = cudf::cast(*col, cudfType, stream);                             \
       }                                                                       \
       return col;                                                             \
@@ -487,7 +491,8 @@ bool hasFinalAggs(
 
 auto toAggregators(
     core::AggregationNode const& aggregationNode,
-    exec::OperatorCtx const& operatorCtx) {
+    exec::OperatorCtx const& operatorCtx,
+    const RowTypePtr& outputType) {
   auto const step = aggregationNode.step();
   bool const isGlobal = aggregationNode.groupingKeys().empty();
   auto const& inputRowSchema = aggregationNode.sources()[0]->outputType();
@@ -530,7 +535,9 @@ auto toAggregators(
     const auto originalName = getOriginalName(kind);
     const auto resultType = exec::isPartialOutput(companionStep)
         ? exec::Aggregate::intermediateType(originalName, argumentTypes)
-        : exec::Aggregate::finalType(originalName, argumentTypes);
+        : outputType->childAt(i);
+
+    // const auto resultType = outputType->childAt(i);
     aggregators.push_back(createAggregator(
         companionStep, kind, inputIndex, constant, isGlobal, resultType));
   }
@@ -539,7 +546,8 @@ auto toAggregators(
 
 auto toIntermediateAggregators(
     core::AggregationNode const& aggregationNode,
-    exec::OperatorCtx const& operatorCtx) {
+    exec::OperatorCtx const& operatorCtx,
+    const RowTypePtr& outputType) {
   auto const step = core::AggregationNode::Step::kIntermediate;
   bool const isGlobal = aggregationNode.groupingKeys().empty();
   auto const& inputRowSchema = aggregationNode.outputType();
@@ -558,8 +566,10 @@ auto toIntermediateAggregators(
       argumentTypes.push_back(arg->type());
     }
     const auto originalName = getOriginalName(kind);
-    const auto resultType =
-        exec::Aggregate::finalType(originalName, argumentTypes);
+    auto const companionStep = getCompanionStep(kind, step);
+    const auto resultType = exec::isPartialOutput(companionStep)
+        ? exec::Aggregate::intermediateType(originalName, argumentTypes)
+        : outputType->childAt(i);
     aggregators.push_back(createAggregator(
         step, kind, inputIndex, constant, isGlobal, resultType));
   }
@@ -613,9 +623,9 @@ void CudfHashAggregation::initialize() {
   // We're postponing this for now.
 
   numAggregates_ = aggregationNode_->aggregates().size();
-  aggregators_ = toAggregators(*aggregationNode_, *operatorCtx_);
+  aggregators_ = toAggregators(*aggregationNode_, *operatorCtx_, outputType_);
   intermediateAggregators_ =
-      toIntermediateAggregators(*aggregationNode_, *operatorCtx_);
+      toIntermediateAggregators(*aggregationNode_, *operatorCtx_, outputType_);
 
   // Check that aggregate result type match the output type.
   // TODO: This is output schema validation. In velox CPU, it's done using

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -32,6 +32,7 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
     cudf::aggregation::Kind kind;
     uint32_t inputIndex;
     VectorPtr constant;
+    TypePtr resultType;
 
     virtual void addGroupbyRequest(
         cudf::table_view const& tbl,
@@ -52,12 +53,14 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
         cudf::aggregation::Kind kind,
         uint32_t inputIndex,
         VectorPtr constant,
-        bool isGlobal)
+        bool isGlobal,
+        const TypePtr& _resultType)
         : step(step),
           is_global(isGlobal),
           kind(kind),
           inputIndex(inputIndex),
-          constant(constant) {}
+          constant(constant),
+          resultType(_resultType) {}
   };
 
   CudfHashAggregation(

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -162,3 +162,7 @@ target_link_libraries(
   gtest_main)
 
 add_subdirectory(utils)
+
+if(${VELOX_ENABLE_SPARK_FUNCTIONS})
+  add_subdirectory(sparksql)
+endif()

--- a/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/AggregationTest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::exec::sparksql::test {
+
+class AggregationTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    functions::aggregate::sparksql::registerAggregateFunctions("");
+    filesystems::registerLocalFileSystem();
+    // After register supports function prefix, we could register the function
+    // with spark_ to align with sparksql AverageAggregationTest, the
+    // function name overwrite may not work well in some condition.
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+  }
+};
+
+TEST_F(AggregationTest, sumReal) {
+  // spark sum:
+  // exec::AggregateFunctionSignatureBuilder()
+  // .returnType("double")
+  // .intermediateType("double")
+  // .argumentType("real")
+  // .build(),
+  // presto sum:
+  // exec::AggregateFunctionSignatureBuilder()
+  //       .returnType("real")
+  //       .intermediateType("double")
+  //       .argumentType("real")
+  //       .build(),
+  // The sum(real) final result type is different.
+  auto data = makeRowVector({makeFlatVector<float>({3.4028, 3.1})});
+  auto vectors = {data};
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation({}, {"sum(c0)"})
+                  .finalAggregation()
+                  .planNode();
+  auto expected = makeRowVector({"c0"}, {makeConstant<double>(6.5028, 1)});
+  assertQuery(plan, expected);
+}
+
+} // namespace facebook::velox::exec::sparksql::test

--- a/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(
+  velox_cudf_spark_aggregates_test
+  AggregationTest.cpp
+  Main.cpp)
+
+add_test(velox_cudf_spark_aggregates_test
+         velox_cudf_spark_aggregates_test)
+
+target_link_libraries(
+  velox_cudf_spark_aggregates_test
+  velox_cudf_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  velox_functions_aggregates_test_lib
+  velox_functions_spark
+  velox_functions_spark_aggregates
+  velox_hive_connector
+  velox_vector_fuzzer
+  gflags::gflags
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/experimental/cudf/tests/sparksql/Main.cpp
+++ b/velox/experimental/cudf/tests/sparksql/Main.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/process/ThreadDebugInfo.h"
+
+#include <folly/Unit.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+// This main is needed for some tests on linux.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  // Signal handler required for ThreadDebugInfoTest
+  facebook::velox::process::addDefaultFatalSignalHandler();
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Before that, use the hard code Presto agg function return type as result type, change to use the result type from Aggregate function entry for spark and presto compatibility, resolve TPCH Q4
```
Error Code: INVALID_STATE
Reason: Cannot change vector type from ROW<"0":VARCHAR,"1":INTEGER> to ROW<n0_0:VARCHAR,n1_1:BIGINT>. The old and new types can be different logical types, but the underlying physical types must match.
Retriable: False
Expression: type_->kindEquals(type)
Context: Operator: CudfToVelox[1-to-velox] 3
Function: setType
File: /opt/gluten/dev/../ep/build-velox/build/velox_ep/velox/vector/BaseVector.h
```