### PR TITLE
[DNM] Fix TPCH Q1 col not found

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -516,10 +516,14 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     return addPrecomputeInstruction(fieldExpr->name(), likeExpr);
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
+    const auto fieldName =
+        fieldExpr->inputs().empty() ? name : fieldExpr->inputs()[0]->name();
     for (size_t sideIdx = 0; sideIdx < inputRowSchema.size(); ++sideIdx) {
       auto& schema = inputRowSchema[sideIdx];
-      if (schema.get()->containsChild(name)) {
-        auto columnIndex = schema.get()->getChildIdx(name);
+      if (schema.get()->containsChild(fieldName)) {
+        auto columnIndex = schema.get()->getChildIdx(fieldName);
+        // This column may be complex data type like ROW, we need to get the
+        // name from row. Push fieldName.name to the tree.
         auto side = static_cast<cudf::ast::table_reference>(sideIdx);
         return tree.push(cudf::ast::column_reference(columnIndex, side));
       }


### PR DESCRIPTION
FieldReference might be a complex data type like ROW, need to reference the column in complex data type.
```
expr[0] (c1_c2).c1
c1
  c1_c2
expr[1] (c1_c2).c2
c2
  c1_c2
```