### PR TITLE
Fix try_cast to pass TPCH Q20

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -245,6 +245,7 @@ const std::unordered_set<std::string> supportedOps = {
     "between",
     "in",
     "cast",
+    "try_cast",
     "switch",
     "year",
     "length",
@@ -433,7 +434,7 @@ cudf::ast::expression const& AstContext::pushExprToTree(
       result = &treeNode;
     }
     return *result;
-  } else if (name == "cast") {
+  } else if (name == "cast" || name == "try_cast") {
     VELOX_CHECK_EQ(len, 1);
     auto const& op1 = pushExprToTree(expr->inputs()[0]);
     if (expr->type()->kind() == TypeKind::INTEGER) {

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -245,7 +245,6 @@ const std::unordered_set<std::string> supportedOps = {
     "between",
     "in",
     "cast",
-    "try_cast",
     "switch",
     "year",
     "length",


### PR DESCRIPTION
try_cast semantic is similar to cast, but different with cast when it can not cast successfully , but cudf does not have try_cast operation, so use cast instead.