### PR TITLE
Fix TPCH Q7 year output type

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -365,6 +365,7 @@ cudf::ast::expression const& AstContext::pushExprToTree(
 
   auto& name = expr->name();
   auto len = expr->inputs().size();
+  auto& type = expr->type();
 
   if (name == "literal") {
     auto c = dynamic_cast<ConstantExpr*>(expr.get());
@@ -472,8 +473,15 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     VELOX_CHECK_NOT_NULL(fieldExpr, "Expression is not a field");
 
     auto const& colRef = addPrecomputeInstruction(fieldExpr->name(), "year");
+    if (type->kind() == TypeKind::BIGINT) {
+      // Presto returns int64.
+      return tree.push(Operation{Op::CAST_TO_INT64, colRef});
+    } else {
+      // Cudf returns smallint while spark returns int, cast the output column
+      // in execution.
+      return colRef;
+    }
 
-    return tree.push(Operation{Op::CAST_TO_INT64, colRef});
   } else if (name == "length") {
     VELOX_CHECK_EQ(len, 1);
 


### PR DESCRIPTION
For Q7, the year type returns integer while presto returns int64_t and cudf returns smallint, but I don't find a operator to cast column to int32, there is only CAST_TO_INT64
```
 -- Project[16][expressions: (n16_7:VARCHAR, "n15_11"), (n16_8:VARCHAR, "n15_13"), (n16_9:INTEGER, year("n15_9")), (n16_10:DOUBLE, multiply("n15_7",subtract(1,"n15_8")))] -> n16_7:VARCHAR, n16_8:VARCHAR, n16_9:INTEGER, n16_10:DOUBLE

Cannot change vector type from ROW<"0":VARCHAR,"1":VARCHAR,"2":SMALLINT,"3":DOUBLE> to ROW<n16_7:VARCHAR,n16_8:VARCHAR,n16_9:INTEGER,n17_3:DOUBLE>. The old and new types can be different logical types, but the underlying physical types must match.
```
I'm not sure we could add CAST_TO_INT32 like this one, https://github.com/rapidsai/cudf/pull/9379/files
Alternatively, as a workaround, we could cast the column in CudfFilterProject operator