### PR TITLE
Fixes to enable gluten TPCH runs (part 2)

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1973,6 +1973,17 @@ VectorPtr importFromArrowImpl(
         arrowArray.n_buffers,
         3,
         "Expecting three buffers as input for string types.");
+    if (arrowSchema.format[0] == 'U' || arrowSchema.format[0] == 'Z') {
+      return createStringFlatVector(
+          pool,
+          type,
+          nulls,
+          arrowArray.length,
+          static_cast<const int64_t*>(arrowArray.buffers[1]), // offsets
+          static_cast<const char*>(arrowArray.buffers[2]), // values
+          arrowArray.null_count,
+          wrapInBufferView);
+    }
     return createStringFlatVector(
         pool,
         type,


### PR DESCRIPTION
- Add "startswith", "endswith", "contains" to expression evaluator
- Add "substring" as alias for "str" to expression evaluator
- Add 2nd argument to "like"
- Add support for large utf-8 string in importFromArrow because cudf supports large strings column with int64 offset column
with these changes, all 22 TPCH queries runs successfully in Gluten for scale factor 100, in single machine.
