### PR TITLE
Allow StreamingAggregation operator to be replaced with CudfHashAggre…

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -38,6 +38,7 @@
 #include "velox/exec/Limit.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/OrderBy.h"
+#include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/TopN.h"
 
@@ -150,6 +151,7 @@ bool CompileState::compile(bool force_replace) {
                    exec::OrderBy,
                    exec::TopN,
                    exec::HashAggregation,
+                   exec::StreamingAggregation,
                    exec::Limit,
                    exec::LocalPartition,
                    exec::LocalExchange,
@@ -170,6 +172,7 @@ bool CompileState::compile(bool force_replace) {
                exec::OrderBy,
                exec::TopN,
                exec::HashAggregation,
+               exec::StreamingAggregation,
                exec::Limit,
                exec::LocalPartition,
                exec::AssignUniqueId>(op) ||
@@ -182,6 +185,7 @@ bool CompileState::compile(bool force_replace) {
                exec::OrderBy,
                exec::TopN,
                exec::HashAggregation,
+               exec::StreamingAggregation,
                exec::Limit,
                exec::LocalExchange,
                exec::AssignUniqueId>(op) ||
@@ -278,9 +282,11 @@ bool CompileState::compile(bool force_replace) {
       VELOX_CHECK(planNode != nullptr);
       replaceOp.push_back(std::make_unique<CudfTopN>(id, ctx, planNode));
       replaceOp.back()->initialize();
-    } else if (auto hashAggOp = dynamic_cast<exec::HashAggregation*>(oper)) {
+    } else if (
+        dynamic_cast<exec::HashAggregation*>(oper) or
+        dynamic_cast<exec::StreamingAggregation*>(oper)) {
       auto planNode = std::dynamic_pointer_cast<const core::AggregationNode>(
-          getPlanNode(hashAggOp->planNodeId()));
+          getPlanNode(oper->planNodeId()));
       VELOX_CHECK(planNode != nullptr);
       replaceOp.push_back(
           std::make_unique<CudfHashAggregation>(id, ctx, planNode));
@@ -359,6 +365,7 @@ bool CompileState::compile(bool force_replace) {
             return isAnyOf<
                        exec::OrderBy,
                        exec::HashAggregation,
+                       exec::StreamingAggregation,
                        exec::Limit,
                        exec::LocalPartition,
                        exec::LocalExchange,


### PR DESCRIPTION
Presto produces a `StreamingAggregation` Operator in Query 21 which is an optimization on HashAggregation where the input is pre-grouped/sorted. Ideally we would take advantage of this by passing pre-sorted property to cudf groupby but replacing it with a regular CudfHashAggregation also works for now and helps shave off 20% of Q21's runtime even without this property.  