### PR TITLE
fix(build): Fix numactl-libs install after CUDF 25.10 upgrade

### DIFF
--- a/scripts/setup-centos-adapters.sh
+++ b/scripts/setup-centos-adapters.sh
@@ -52,14 +52,14 @@ function install_cuda {
   dnf config-manager --add-repo "$repo_url"
   local dashed
   dashed="$(echo "$version" | tr '.' '-')"
-  dnf_install --repo cuda-rhel9-"$arch" \
+  dnf_install \
     cuda-compat-"$dashed" \
     cuda-driver-devel-"$dashed" \
     cuda-minimal-build-"$dashed" \
     cuda-nvrtc-devel-"$dashed" \
     libcufile-devel-"$dashed" \
-    libnvjitlink-devel-"$dashed"
-  dnf_install numactl-libs
+    libnvjitlink-devel-"$dashed" \
+    numactl-libs
 }
 
 function install_adapters_deps_from_dnf {


### PR DESCRIPTION
Remove the `--repo` option added by @karthikeyann as this breaks the install of `numactl-libs` which is not part of CUDA and therefore not in that repo, and also is incompatible with ARM as there is no `cuda-rhel9-aarch64` repo.

NOTE that this PR is submitted against our `merged-prs` branch directly, because the underlying PR it updates has not yet been landed upstream.