### PR TITLE
Add CUDF UPPER() string function support

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -338,6 +338,7 @@ const std::unordered_set<std::string> supportedOps = {
     "split",
     "coalesce",
     "lower",
+    "upper",
     "round",
     "hash_with_seed"};
 
@@ -692,6 +693,13 @@ cudf::ast::expression const& AstContext::pushExprToTree(
         std::dynamic_pointer_cast<FieldReference>(expr->inputs()[0]);
     VELOX_CHECK_NOT_NULL(fieldExpr, "Expression is not a field");
     return addPrecomputeInstruction(fieldExpr->name(), "lower");
+  } else if (name == "upper") {
+    VELOX_CHECK_EQ(len, 1);
+
+    auto fieldExpr =
+        std::dynamic_pointer_cast<FieldReference>(expr->inputs()[0]);
+    VELOX_CHECK_NOT_NULL(fieldExpr, "Expression is not a field");
+    return addPrecomputeInstruction(fieldExpr->name(), "upper");
   } else if (name == "substr" or name == "substring") {
     // Build a cudf expression node for recursive evaluation
     auto node = CudfExpressionNode::create(expr);
@@ -1481,6 +1489,12 @@ void addPrecomputedColumns(
       inputTableColumns.emplace_back(std::move(newColumn));
     } else if (ins_name == "lower") {
       auto newColumn = cudf::strings::to_lower(
+          inputTableColumns[dependent_column_index]->view(),
+          stream,
+          cudf::get_current_device_resource_ref());
+      inputTableColumns.emplace_back(std::move(newColumn));
+    } else if (ins_name == "upper") {
+      auto newColumn = cudf::strings::to_upper(
           inputTableColumns[dependent_column_index]->view(),
           stream,
           cudf::get_current_device_resource_ref());


### PR DESCRIPTION
Implements GPU-accelerated UPPER() string function in the CUDF expression evaluator. This enables uppercase string transformation on GPU for improved performance in Presto Native queries.

Implementation details:
- Added 'upper' to supportedOps set
- Added expression handler for UPPER function calls
- Added precomputed column handler using cudf::strings::to_upper()
- Follows the same pattern as existing LOWER() implementation

Functionality:
- Works in SELECT, WHERE, and ORDER BY clauses
- Requires field references (column names)
- Fully GPU-accelerated using CUDF strings library
- Compatible with other string functions (e.g., LOWER)

Limitations:
- Does not support literal strings (requires column references)
- Not yet supported in HashJoin filter conditions (precomputation)

Tested with:
- Information schema queries
- Complex WHERE and ORDER BY clauses
- Combination with LOWER function

Related: Part of ongoing CUDF string function improvements