### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
       interval: weekly
     commit-message:
       prefix: 'build(ci): '
+    cooldown:
+      default-days: 7

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -46,7 +46,7 @@ jobs:
       cudf_SOURCE: BUNDLED
       CUDA_VERSION: "12.8"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -144,7 +144,7 @@ jobs:
 #       run: |
 #         mkdir -p '${{ env.CCACHE_DIR }}'
 
-#     - uses: actions/checkout@v4
+#     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 #       with:
 #         path: velox
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
         exclude: .*\.clang-(tidy|format)
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.7.0
+    rev: v1.24.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275