### PR TITLE
fix zizmor checks

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -46,7 +46,7 @@ jobs:
       cudf_SOURCE: BUNDLED
       CUDA_VERSION: "12.8"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -144,7 +144,7 @@ jobs:
 #       run: |
 #         mkdir -p '${{ env.CCACHE_DIR }}'
 
-#     - uses: actions/checkout@v4
+#     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 #       with:
 #         path: velox
 

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -29,10 +29,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   # title-check:


### PR DESCRIPTION
https://github.com/rapidsai/velox/pull/111 was closed with the conclusion "let's try to upstream fixes instead of committing them directly here", but I think that was misguided.

upstream has been enforcing the `zizmor` checks since June 2025 (https://github.com/facebookincubator/velox/pull/13361) and you can see we have that here on `velox-cudf` (the default branch):

https://github.com/rapidsai/velox/blob/0b375b2e359316854e11c0f6f18587ac5c8989b2/.pre-commit-config.yaml#L117-L120

https://github.com/rapidsai/velox/blob/0b375b2e359316854e11c0f6f18587ac5c8989b2/.github/zizmor.yml#L14-L17

The non-pinned uses of third-party GitHub Actions **are specifically places where RAPIDS has deviated from the upstream**, so should be fixed directly here.